### PR TITLE
Add basic covid response page

### DIFF
--- a/scripts/testserver.bash
+++ b/scripts/testserver.bash
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -m # enable job control
-echo "Starting test server..."
+echo "Starting test server on port $1..."
 echo "Stop the server with Ctrl-C"
-python3 -m http.server 8000 --directory ./virginia.clubrunning.org & # start server
+python3 -m http.server $1 --directory ./virginia.clubrunning.org & # start server
 sleep 1
-open http://localhost:8000
+open http://localhost:$1
 fg

--- a/virginia.clubrunning.org/covid.html
+++ b/virginia.clubrunning.org/covid.html
@@ -70,7 +70,8 @@
                     <p><strong>Schedule.</strong> We'll hold official practices twice daily Monday-Friday. Morning
                         practice starts at
                         <strong>8:00am</strong> and afternoon practice starts at <strong>4:00pm</strong>. We'll meet at
-                        <strong>Nameless Field.</strong>
+                        <strong><a href="https://goo.gl/maps/pWyQrmdzo1gZz8jF7" class="no-arrow">Nameless
+                                Field.</a></strong>
                     </p>
                 </li>
                 <li>
@@ -84,7 +85,8 @@
                 </li>
                 <li>
                     <p><strong>Symptoms.</strong> Do not attend practice if you are experiencing symptoms consistent
-                        with COVID.</p>
+                        with COVID or have been in close contact with a COVID-positive person. Refer to University
+                        guidance regarding appropriate quarantine protocol.</p>
                 </li>
                 <li>
                     <p><strong>Masks.</strong> Masks are <strong>required</strong> before, during, and after your runs
@@ -118,7 +120,12 @@
                     href="mailto:mma3bj@virginia.edu">email our president.</a></p>
 
             <h2 class="pad-bottom">Social</h2>
-            <p>Our social chairs are hard at work dreaming up creative events to bring the club together. Make sure
+            <p>Our social chairs are hard at work dreaming up creative events (small group in-person and virtual) to
+                bring the club together. Currently planned events can be found on the <a
+                    href="https://docs.google.com/spreadsheets/d/1_hzmXZ_3FX_eEgxvBPY5oxOySQeHcC3Udpagx92lsZU/edit#gid=1403789779"
+                    class="no-arrow">2021 social calendar</a>.
+
+                Make sure
                 you're
                 <a class="no-arrow" href="https://lists.virginia.edu/sympa/subscribe/club-running">subscribed to our
                     mailing list</a> and

--- a/virginia.clubrunning.org/covid.html
+++ b/virginia.clubrunning.org/covid.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>COVID Response &vert; Club Running at UVA</title>
+    <link rel="stylesheet" href="static/styles/charlottesville.css">
+
+
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="manifest" href="/site.webmanifest">
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#ff8d53">
+    <meta name="msapplication-TileColor" content="#ff8d53">
+    <meta name="theme-color" content="#70b9ee">
+</head>
+
+<body>
+    <div id="header">
+        <a href="." class="site-title">
+            <div class="container">
+                <div class="logo"></div>
+                <h1>Club Running</h1>
+            </div>
+        </a>
+        <div class="site-navigation">
+            <ul>
+                <li><a href=".">about</a></li>
+                <li><a href="meets">meets</a></li>
+                <li><a href="invitational">Cav Invite</a></li>
+                <li><a href="runathon">Run-a-thon</a></li>
+                <li><a href="men">men</a></li>
+                <li><a href="women">women</a></li>
+                <li><a href="records">records</a></li>
+                <li><a href="charlottesville">Charlottesville</a></li>
+                <li><a href="contact">contact us</a></li>
+            </ul>
+        </div>
+        <div class="mobile-menu" onclick="toggleMobileNavigation()">
+            <div class="hamburger hamburger--collapse">
+                <div class="hamburger-box">
+                    <div class="hamburger-inner"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="splash page-title orange">
+        <div class="container fill">
+            <div class="background orange">
+                <h1>COVID-19 Response</h1>
+                <h2>Practicing<span class="desktop-only"> in-person</span> safely &amp; responsibly</h2>
+            </div>
+        </div>
+    </div>
+
+    <div class="splash white">
+        <div class="container fill">
+            <p>Club Running is working to bring runners together during these isolating times. We're moving forward with
+                practice, emphasizing safety and responsibility.
+            </p>
+            <br />
+            <h2 class="pad-bottom">In-Person Practice</h2>
+            <p>Spring 2021 in-person practice begins on <strong>Monday, February 15.</strong> We're making
+                significant modifications to our typical practice plan to make sure our members are safe.</p>
+            <ul>
+                <li>
+                    <p><strong>Schedule.</strong> We'll hold official practices twice daily Monday-Friday. Morning
+                        practice starts at
+                        <strong>8:00am</strong> and afternoon practice starts at <strong>4:00pm</strong>. We'll meet at
+                        <strong>Nameless Field.</strong>
+                    </p>
+                </li>
+                <li>
+                    <p><strong>Spreadsheet.</strong> You can sign up to attend in-person practice through that week's
+                        spreadsheet. Make sure you're <a class="no-arrow"
+                            href="https://lists.virginia.edu/sympa/subscribe/club-running">on our
+                            mailing list</a> to
+                        receive the spreadsheet. If you missed this week's spreadsheet, email <a
+                            href="mailto:jek4qv@virginia.edu?subject=Practice%20Spreadsheet&body=Could%20you%20please%20forward%20me%20this%20week's%20practice%20signup%20spreadsheet%3F"
+                            class="no-arrow">our webmaster.</a></p>
+                </li>
+                <li>
+                    <p><strong>Symptoms.</strong> Do not attend practice if you are experiencing symptoms consistent
+                        with COVID.</p>
+                </li>
+                <li>
+                    <p><strong>Masks.</strong> Masks are <strong>required</strong> before, during, and after your runs
+                        at practice. If you don't
+                        have a suitable running mask, we'll provide one. Email <a class="no-arrow"
+                            href="mailto:wmm6bm@virginia.edu?subject=Buff%20Mask&body=To%20whom%20it%20may%20concern%2C%0D%0A%0D%0AI%20find%20your%20offer%20of%20a%20free%20Buff%20mask%20for%20my%20runs%20quite%20enticing.%20The%20things%20I%20would%20do%20to%20have%20a%20Buff%20mask%20of%20my%20very%20own...%20Please%2C%20reply%20to%20this%20email%20and%20let%20me%20know%20how%20I%20can%20get%20my%20hands%20on%20one%20of%20those%20bad%20boys.%0D%0A%0D%0ARegards%2C%0D%0AMaskless%20Club%20Runner">our
+                            secretary</a> to get yours for free.</p>
+                </li>
+                <li>
+                    <p>
+                        <strong>Group size.</strong> In compliance with the University gathering limit, <strong>make
+                            sure you're running in groups of
+                            six people or fewer.</strong> It's okay if more than six people show up to practice, but
+                        it's important that you quickly divide into appropriately sized groups.
+                    </p>
+                </li>
+                <li>
+                    <p><strong>Observe social distancing</strong> before runs, during runs, and after them. Stay six
+                        feet apart from others whenever possible.</p>
+                </li>
+                <li>
+                    <p><strong>Contact tracing.</strong> While we can't require you to, we hope you'll let <a
+                            href="mailto:mma3bj@virginia.edu" class="no-arrow">our president</a> know if
+                        you or someone very close to you
+                        contracts COVID-19. That way, we can notify your recent running partners and encourage them to
+                        self-isolate appropriately. You will not be punished, and we won't use your name
+                        when we notify your contacts. </p>
+                </li>
+            </ul>
+            <p>If you have any questions or concerns about these policies, do not hesitate to <a
+                    href="mailto:mma3bj@virginia.edu">email our president.</a></p>
+
+            <h2 class="pad-bottom">Social</h2>
+            <p>Our social chairs are hard at work dreaming up creative events to bring the club together. Make sure
+                you're
+                <a class="no-arrow" href="https://lists.virginia.edu/sympa/subscribe/club-running">subscribed to our
+                    mailing list</a> and
+                <a class="no-arrow"
+                    href="mailto:jek4qv@virginia.edu?subject=Club%20GroupMe&body=Enter%20your%20details%20below%20to%20be%20added%20to%20the%20club%20GroupMe%3A%0D%0A%0D%0AName%3A%0D%0APhone%20number%3A">in
+                    the club GroupMe</a> to keep up to date with new social events.
+            </p>
+        </div>
+    </div>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script type="text/javascript">
+        let version = (new Date()).getTime();
+        let script = document.createElement("script");
+        script.src = "static/scripts/app.js?v=" + version;
+        document.body.appendChild(script);
+    </script>
+</body>
+
+</html>

--- a/virginia.clubrunning.org/covid.html
+++ b/virginia.clubrunning.org/covid.html
@@ -118,7 +118,7 @@
             </ul>
             <p>If you have any questions or concerns about these policies, do not hesitate to <a
                     href="mailto:mma3bj@virginia.edu">email our president.</a></p>
-
+            <br />
             <h2 class="pad-bottom">Social</h2>
             <p>Our social chairs are hard at work dreaming up creative events (small group in-person and virtual) to
                 bring the club together. Currently planned events can be found on the <a
@@ -133,6 +133,10 @@
                     href="mailto:jek4qv@virginia.edu?subject=Club%20GroupMe&body=Enter%20your%20details%20below%20to%20be%20added%20to%20the%20club%20GroupMe%3A%0D%0A%0D%0AName%3A%0D%0APhone%20number%3A">in
                     the club GroupMe</a> to keep up to date with new social events.
             </p>
+            <br />
+            <h2 class="pad-bottom">Stay in the loop</h2>
+            <p>As further information becomes available, updates will be posted here and on our ListServ. <a
+                    href="https://goo.gl/maps/pWyQrmdzo1gZz8jF7">Subscribe here.</a></p>
         </div>
     </div>
 

--- a/virginia.clubrunning.org/index.html
+++ b/virginia.clubrunning.org/index.html
@@ -48,7 +48,6 @@
 			</div>
 		</div>
 	</div>
-
 	<div class="splash full-height-landscape blue" id="landing-title"
 		style="background-image: url('static/images/splash/landing/team_up.jpeg')">
 		<div class="container">
@@ -56,6 +55,16 @@
 				<h1>Club Running at UVA</h1>
 				<h2 id="motto">Push yourself. Stay fit. Find community.</h2>
 			</div>
+		</div>
+	</div>
+
+	<div class="splash white">
+		<div class="container fill">
+			<h3 class="pad-bottom">COVID-19 Update</h3>
+			<p>
+				Club Running is resuming in-person, small group practices on <strong>Monday, February 15</strong>. <a
+					href="/covid">Learn more here.</a>
+			</p>
 		</div>
 	</div>
 


### PR DESCRIPTION
Closes #4. Implements a COVID response page.

To-do:
[x] Implement basic response page
[ ] Link to this page from other pages, perhaps using a banner
[ ] Refine response page with Wednesday Weekly updates